### PR TITLE
missing packages from debian minimal + turn on apt non-interactive mode in debian_install

### DIFF
--- a/utils/debian_install.sh
+++ b/utils/debian_install.sh
@@ -6,12 +6,12 @@
 
 # list of programs to be installed:
 daemons=(dnsmasq privoxy squid3 polipo tor)
-pkgs=(daemontools iptables ebtables)
+pkgs=(daemontools iptables ebtables gettext-base procps net-tools)
 
 # installation process for daemons
 # (deactivates start at boot)
 for i in $daemons; do
-	apt-get install $i
+	apt-get install -y $i
 done
 
 # deactivate start at boot
@@ -23,6 +23,5 @@ done
 
 # installation of packages
 for i in $pkgs; do
-	apt-get install $i
+	apt-get install -y $i
 done
-


### PR DESCRIPTION
Just a small change to enable non-interactive bootstrap of dowse dependencies on a debian minimal 
(helpful in automated deploy, e.g. Dockefiles or ansible playbooks)  
