### PR TITLE
Building from source on non-apt distros

### DIFF
--- a/src/compile.sh
+++ b/src/compile.sh
@@ -34,10 +34,10 @@ case $1 in
             [[ "$auth[(w)3]" = "0" ]] || needsuid=$(( $needsuid + 1 ))
 
             [[ $needsuid = 0 ]] || {
-                sudo=""; command -v sudo && sudo="sudo "
+                sudo="(root)# "; command -v sudo && sudo="sudo "
                 act ""
                 error "You need to suid the privilege escalation wrapper sup."
-                act "Please issue the following commands as root:"
+                act "Please issue the following commands:"
                 cat <<EOF
 
 ${sudo}chown root:root $R/run/sup
@@ -67,6 +67,7 @@ EOF
         [[ -r $R/run/pgl ]] || {
             pushd $R/src/pgl
             ./configure --without-qt4 --disable-dbus --enable-lowmem \
+					--disable-networkmanager \
 	                --prefix $R/run/pgl --sysconfdir $R/run/pgl/etc \
 	                --with-initddir=$R/run/pgl/init.d \
                 && \

--- a/src/paths.sh
+++ b/src/paths.sh
@@ -40,20 +40,30 @@ execmap=(
 
 # check if on Gentoo
 command -v emerge >/dev/null && {
-
     execmap=(
-        dnscrypt      /usr/sbin/dnscrypt-proxy
+		ifconfig      /bin/ifconfig
+		route         /bin/route
+        dnscrypt      $R/run/dnscrypt-proxy
         dnscap        $R/src/dnscap/dnscap
-        dnsmasq       /usr/sbin/dnsmasq
-        redis-cli     /usr/bin/redis-cli
-        redis-server  /usr/sbin/redis-server
-        iptables      /sbin/iptables
+        dnsmasq       $R/run/dnsmasq
+        redis-cli     $R/run/redis-cli
+        redis-server  $R/run/redis-server
+		tor           $R/run/tor
+		kill          /bin/kill
+		xtables-multi /sbin/xtables-multi
         ebtables      /sbin/ebtables
         sysctl        /usr/sbin/sysctl
         pgl           $R/run/pgl/bin/pglcmd
         libjemalloc   /usr/lib64/libjemalloc.so.2
+		nmap          /usr/bin/nmap
     )
 }
+
+pkgmap=(
+	dnsmasq      http://www.thekelleys.org.uk/dnsmasq/dnsmasq-2.75.tar.gz
+	redis        http://download.redis.io/releases/redis-3.0.7.tar.gz
+	tor          https://www.torproject.org/dist/tor-0.2.7.6.tar.gz
+)
 
 case `uname -m` in
     arm*)

--- a/src/paths.sh
+++ b/src/paths.sh
@@ -43,11 +43,11 @@ command -v emerge >/dev/null && {
     execmap=(
 		ifconfig      /bin/ifconfig
 		route         /bin/route
-        dnscrypt      $R/run/dnscrypt-proxy
-        dnscap        $R/src/dnscap/dnscap
-        dnsmasq       $R/run/dnsmasq
-        redis-cli     $R/run/redis-cli
-        redis-server  $R/run/redis-server
+		dnscrypt      $R/run/dnscrypt-proxy
+		dnscap        $R/src/dnscap/dnscap
+		dnsmasq       $R/run/dnsmasq
+		redis-cli     $R/run/redis-cli
+		redis-server  $R/run/redis-server
 		tor           $R/run/tor
 		kill          /bin/kill
 		xtables-multi /sbin/xtables-multi


### PR DESCRIPTION
This includes a function called source-build which will run instead of deb-download if the distribution is not apt-based.

Currently builds with default options, but is easily modified for what's needed.