### PR TITLE
fixed builds of netdiscover and pgld, removed -O2

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Installation and activation takes a few steps and needs root:
 2. Install all requirements, here below the list of packages:
 
 ```
-zsh iptables ebtables gettext-base procps net-tools
+zsh iptables ebtables gettext-base procps net-tools autoconf
 libssl-dev libbind-dev libpcap-dev unzip wget gcc make liblo-dev
 libnetfilter-conntrack3 libnetfilter-queue-dev libjemalloc-dev
 libseccomp2 libsodium-dev libhiredis-dev libkmod-dev

--- a/src/compile.sh
+++ b/src/compile.sh
@@ -11,15 +11,16 @@ source $R/zlibs/zuper
 source $R/zlibs/zuper.init
 
 PREFIX=${PREFIX:-/usr/local/dowse}
-CFLAGS="-Wall -fPIC -fPIE -Os -O2"
+CFLAGS="-Wall -fPIC -fPIE -Os"
 LDFLAGS="-fPIC -fPIE -pie"
 
 case $1 in
     netdiscover)
         [[ -x $R/build/netdiscover ]] || {
             pushd $R/src/netdiscover
-            CFLAGS="$CFLAGS" ./configure --prefix=${PREFIX} &&
-                make &&
+			autoreconf && \
+            CFLAGS="$CFLAGS" ./configure --prefix=${PREFIX} && \
+                make && \
                 install -s -p src/netdiscover $R/build
             popd
         }
@@ -51,11 +52,12 @@ case $1 in
         [[ -x $R/build/pgld ]] || {
             pushd $R/src/pgl
             ./configure --without-qt4 --disable-dbus --enable-lowmem \
+						--disable-networkmanager \
                         --prefix ${PREFIX}/pgl \
                         --sysconfdir ${HOME}/.dowse/pgl/etc \
                         --with-initddir=${PREFIX}/pgl/init.d \
                 && \
-                make pgld/pgld && \
+                make -C pgld && \
                 install -s -p $R/src/pgl/pgld/pgld $R/build
             popd
         }

--- a/src/dnscap/plugins/dowse/Makefile
+++ b/src/dnscap/plugins/dowse/Makefile
@@ -1,6 +1,6 @@
 #CC=colorgcc
 CC = gcc
-CFLAGS = -Wall -Os -O2 -fPIC -I../../../
+CFLAGS = -Wall -Os -fPIC -I../../../
 LIBS = -ljemalloc -lhiredis
 all: dowse.so
 

--- a/src/sup/Makefile
+++ b/src/sup/Makefile
@@ -6,7 +6,7 @@ VERSION=1.1
 USER=root
 GROUP=root
 
-CFLAGS?=-Os -O2
+CFLAGS?=-Os
 
 all: shared
 


### PR DESCRIPTION
Doing research, the -O2 optimization flag used alongside -Os is redundant. -Os
does almost everything -O2 does, while keeping it optimized for size. In these
cases, where -Os is used together with -O2, only -Os is being used and therefore
-O2 is an unneeded addition