### PR TITLE
Load zuper before calling error

### DIFF
--- a/dowse
+++ b/dowse
@@ -21,6 +21,11 @@
 # Software Foundation, Inc., 675 Mass Ave, Cambridge, MA
 # 02139, USA.
 
+# load development libraries if there
+if [[ -r `pwd`/zlibs/zuper-dev/zuper ]]; then
+    func "Zuper loaded from development symlink"
+    source `pwd`/zlibs/zuper-dev/zuper
+else source `pwd`/zlibs/zuper; fi
 
 # {{{ GLOBALS
 
@@ -43,12 +48,6 @@ E=${DOWSE_CONF:-/etc/dowse}
 }
 
 mkdir -p $H
-
-# load development libraries if there
-if [[ -r `pwd`/zlibs/zuper-dev/zuper ]]; then
-    func "Zuper loaded from development symlink"
-    source `pwd`/zlibs/zuper-dev/zuper
-else source `pwd`/zlibs/zuper; fi
 
 # For gettext
 TEXTDOMAIN=dowse


### PR DESCRIPTION
This moves loading of zuper before any call to its functions is made.
