### PR TITLE
Use apr-1-config to retrieve include dir

### DIFF
--- a/src/maria2redis/Makefile
+++ b/src/maria2redis/Makefile
@@ -1,4 +1,4 @@
-INCLUDE =`mariadb_config --include` -I/usr/local/include  -I/usr/local/apr/include -I./
+INCLUDE =`mariadb_config --include` -I/usr/local/include `apr-1-config --includes` -I./
 LIBS    =-lhiredis -L/usr/local/dowse/mysql/plugin  -L/usr/local/apr/lib  -lapr-1  -laprutil-1
 CFLAGS ?=-Wall -O2 -g -D_LARGEFILE64_SOURCE
 LDFLAGS?=-fPIC

--- a/src/maria2redis/lib_mysqludf_redis.h
+++ b/src/maria2redis/lib_mysqludf_redis.h
@@ -41,12 +41,12 @@ typedef long long longlong;
 
 
 //apache portable runtime
-#include <apr-1.0/apu.h>
-#include <apr-1.0/apr.h>
-#include <apr-1.0/apr_queue.h>
-#include <apr-1.0/apr_thread_pool.h>
-#include <apr-1.0/apr_time.h>
-#include <apr-1.0/apr_general.h>
+#include <apu.h>
+#include <apr.h>
+#include <apr_queue.h>
+#include <apr_thread_pool.h>
+#include <apr_time.h>
+#include <apr_general.h>
 
 //fix me!
 #ifdef	__cplusplus


### PR DESCRIPTION
On Arch Linux apr headers are under `/usr/include/apr-1`, while on Debian they are under `/usr/include/apr-1.0`. However, by using `apr-1-config --includes` we cover all cases, even user builds under `/usr/local/include`