### PR TITLE
Use uname instead of arch

### DIFF
--- a/src/compile.sh
+++ b/src/compile.sh
@@ -34,7 +34,7 @@ case $1 in
 
 	maria2redis)
 		pushd $R/src/maria2redis
-		case `arch` in
+		case `uname -m` in
 			i686*) CFLAGS+=" -D_LARGEFILE64_SOURCE=1"
 		esac
 		CFLAGS+=" -Os" \
@@ -47,7 +47,7 @@ case $1 in
 		pushd $R/src/libwebsockets
 		# fix for broken path detection
 		cmakeflags=""
-		case `arch` in
+		case `uname -m` in
 			arm*) cmakeflags+="-DZLIB_LIBRARY:FILEPATH=/usr/lib/arm-linux-gnueabih" ;;
 		esac
 		CFLAGS="$CFLAGS" \

--- a/zlibs/processes
+++ b/zlibs/processes
@@ -89,7 +89,7 @@ start() {
     if command -v $_daemon-exec > /dev/null; then
         # we preload jemalloc for better memory handling
 		# need to detect the path for it
-		case `arch` in
+		case `uname -m` in
 			x86_64)
 				func "set LD_PRELOAD for jemalloc arch x84_64 ($_daemon)"
 				LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1 \


### PR DESCRIPTION
`arch` isn't available under Arch Linux, however [arch documentation](https://www.gnu.org/software/coreutils/manual/html_node/arch-invocation.html) says that is shouldn't be used in scripts as it's not enabled by default in coreutils.
I suggest to replace `arch` by `uname -m`.