### PR TITLE
Add WITH_MYSQL switch to use MySQL instead of MariaDB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ env:
 before_install:
   - sudo add-apt-repository ppa:chris-lea/libsodium -y
   - sudo apt-get -qq -y update
-  - sudo apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install --no-install-recommends -y zsh iptables ebtables sqlite3 procps gettext-base procps net-tools autoconf libssl-dev libbind-dev libpcap-dev unzip wget gcc make libtool liblo-dev libnetfilter-conntrack3 libnetfilter-queue-dev libsqlite3-dev sqlite3 libjemalloc-dev libseccomp2 libsodium-dev libhiredis-dev libkmod-dev libreadline5 libaio1 libpcre3 bind9-host bison gawk libevent-dev libjansson-dev asciidoc uuid-dev libldns-dev python-redis python-hiredis dnsutils valgrind build-essential xmlstarlet libfile-mimeinfo-perl libmariadbclient-dev libb64-dev cproto 
+  - sudo apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install --no-install-recommends -y zsh iptables ebtables sqlite3 procps gettext-base procps net-tools autoconf libssl-dev libbind-dev libpcap-dev unzip wget gcc make libtool liblo-dev libnetfilter-conntrack3 libnetfilter-queue-dev libsqlite3-dev sqlite3 libjemalloc-dev libseccomp2 libsodium-dev libhiredis-dev libkmod-dev libreadline5 libaio1 libpcre3 bind9-host bison gawk libevent-dev libjansson-dev asciidoc uuid-dev libldns-dev python-redis python-hiredis dnsutils valgrind build-essential xmlstarlet libfile-mimeinfo-perl libmysqld-dev libb64-dev cproto libapr1-dev libaprutil1-dev
   - git submodule update --init
 
 script:
-  - make
+  - make WITH_MYSQL=yes
   - sudo make install
   - sudo chown -R $USER $HOME/.dowse
   - cd src/dnscrypt-plugin && ./debug/runtests

--- a/src/Makefile
+++ b/src/Makefile
@@ -90,7 +90,11 @@ modprobe: modprobe.o kmod_log.o
 	$(CC) $(CFLAGS) -o $@ $^ $(LIBS) -lkmod
 
 parse-ip-neigh: parse-ip-neigh.c
+ifeq ($(WITH_MYSQL),yes)
+	$(CC) $(CFLAGS) -o $@ $^ $(LIBS) -DDB_HOST=\"localhost\" -DDB_USER=\"root\" -DDB_PASSWORD=\"p4ssw0rd\" -DDB_SID=\"things\" -DDB_SOCK_DIRECTORY=\"$(HOME)/.dowse/run/mysql/mysqld.sock\"  -I/usr/include/mysql -lmysqld
+else
 	$(CC) $(CFLAGS) -o $@ $^ $(LIBS) -DDB_HOST=\"localhost\" -DDB_USER=\"root\" -DDB_PASSWORD=\"p4ssw0rd\" -DDB_SID=\"things\" -DDB_SOCK_DIRECTORY=\"$(HOME)/.dowse/run/mysql/mysqld.sock\"  -I/usr/include/mariadb -lmariadb
+endif
 
 dowse-to-gource: dowse-to-gource.o
 	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
@@ -98,7 +102,7 @@ dowse-to-gource: dowse-to-gource.o
 dowse-to-osc: dowse-to-osc.o
 	$(CC) $(CFLAGS) -o $@ $^ $(LIBS) -llo
 
-dowse-to-mqtt: mosquitto dowse-to-mqtt.o 
+dowse-to-mqtt: mosquitto dowse-to-mqtt.o
 	$(CC) $(CFLAGS) -o $@ dowse-to-mqtt.o $(LIBS) -L./mosquitto/lib/ -lmosquitto    -lpthread
 
 

--- a/src/maria2redis/Makefile
+++ b/src/maria2redis/Makefile
@@ -1,7 +1,13 @@
-INCLUDE =`mariadb_config --include` -I/usr/local/include `apr-1-config --includes` -I./
+INCLUDE =-I/usr/local/include `apr-1-config --includes` -I./
 LIBS    =-lhiredis -L/usr/local/dowse/mysql/plugin  -L/usr/local/apr/lib  -lapr-1  -laprutil-1
 CFLAGS ?=-Wall -O2 -g -D_LARGEFILE64_SOURCE
 LDFLAGS?=-fPIC
+
+ifeq ($(WITH_MYSQL),yes)
+  INCLUDE+=`mysql_config --include`
+else
+  INCLUDE+=`mariadb_config --include`
+endif
 
 compile:
 	gcc $(LDFLAGS) $(CFLAGS) -g $(INCLUDE)  -I. -shared -rdynamic lib_mysqludf_redis.c  $(LIBS) -o lib_mysqludf_redis_v2.so

--- a/src/webui/Makefile
+++ b/src/webui/Makefile
@@ -11,7 +11,11 @@ TMP=src/.tmp_file
 all: cproto asset
 	rm -f assets/*~
 #	cp -f conf/webui.conf.dist conf/webui.conf
+ifeq ($(WITH_MYSQL),yes)
+	../kore/kore flavor prod_mysql
+else
 	../kore/kore flavor prod
+endif
 	../kore/kore build
 
 echo:

--- a/src/webui/conf/build.conf.dist
+++ b/src/webui/conf/build.conf.dist
@@ -7,9 +7,8 @@
 # cflags=-Wall -D_XOPEN_SOURCE
 
 cflags = -I.. -I../libparse-datetime -I../kore/includes -I../libdowse
-cflags = -I/usr/include/mariadb
 ldflags = ../libparse-datetime/libparse-datetime.a -L../libdowse -l:libdowse.a
-ldflags = -lm -lssl -lcrypto -lmariadb -lhiredis -lb64
+ldflags = -lm -lssl -lcrypto -lhiredis -lb64 -lpthread
 
 # mariadb flags
 cflags = -DDB_USER="root"
@@ -35,6 +34,13 @@ dev {
 }
 
 prod {
-    cflags = -Os -Wall    
+    cflags = -I/usr/include/mariadb
+    cflags = -Os -Wall
+    ldflags = -lmariadb
 }
 
+prod_mysql {
+    cflags = -I/usr/include/mysql
+    cflags = -Os -Wall
+    ldflags = -lmysqld
+}


### PR DESCRIPTION
On both Arch Linux and Ubuntu, MariaDB headers are installed under `/usr/include/mysql` and the library is still named `libmysqld.so`.

While we could include both headers locations (`/usr/include/mysql` and `/usr/include/mariadb`) we cannot link to both libraries `-lmariadb -lmysqld` because only the latter is present on those systems and the build will fail.

~This patch fixes the build on those systems, but (_maybe_) will broke your workflow I guess.~
~I don't know how to handle both cases, however may I ask which distro are you using that installs MariaDB library as `libmariadb.so`?~