### PR TITLE
Consistent DOWSE_HOME

### DIFF
--- a/dowse
+++ b/dowse
@@ -29,7 +29,7 @@ dowse_release_date="5/Apr/2016"
 
 # export DOWSE_PREFIX and DOWSE_HOME to override
 R=${DOWSE_PREFIX:-/usr/local/dowse}
-H=${DOWSE_HOME:-$HOME/.dowse}
+H=${DOWSE_HOME:-$HOME}
 E=${DOWSE_CONF:-/etc/dowse}
 
 #####################


### PR DESCRIPTION
In both [config.mk](https://github.com/dyne/dowse/blob/master/config.mk#L4) and [Makefile](https://github.com/dyne/dowse/blob/master/Makefile#L59) is expected to point at `$HOME`, instead here it's expected to point at `$HOME/.dowse`.