### PR TITLE
Static redis

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "src/node-red"]
 	path = src/node-red
 	url = https://github.com/node-red/node-red.git
+[submodule "src/redis"]
+	path = src/redis
+	url = https://github.com/antirez/redis

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ its simplicity and usefulness. Here a recent backstage video:
 
   Dowse takes control of a LAN by becoming its DHCP server and thereby
   assigning itself as main gateway and DNS server for all clients. It
-  keeps tracks of assigned leases by MAC Address. DNSMasq is the DHCP
-  and DNS daemon.
+  keeps tracks of assigned leases by MAC Address. ISC DHCP
+  and DNSCRYPT-PROXY are used as daemons.
 
   All network traffic is passed through NAT rules for masquerading.
   HTTP traffic (TCP port 80) can be filtered through a transparent
@@ -51,19 +51,12 @@ its simplicity and usefulness. Here a recent backstage video:
   All IP traffic is filtered using configurable blocklists to keep out
   malware, spyware and known bad peers, using Peerguardian2 and Iptables.
 
-  All DNS traffic (UDP port 53) is filtered through Dnscap and
-  analysed to render a graphical representation of traffic. It is also
-  possible to tunnel it via DNSCrypt-proxy, encrypting all traffic
-  (AES/SHA256) before sending it to DNSCrypt.eu or other configurable
-  servers supporting this protocol.
+  All DNS traffic (UDP port 53) is filtered through a DNSCRYPT-PROXY
+  plugin encrypting all traffic (AES/SHA256) and analysed using
+  domain-list to render a graphical representation of traffic.
 
-  In the future, traffic of all kinds may be transparently proxied for
-  monitoring, filtering, and transformation by other applications
-  loaded on the Dowse device.
-
-  All daemons are running as a unique non-privileged UID. The future
-  plan is to separate them using a different UID for each daemon.
-
+  Privilege escalation is managed using https://sup.dyne.org
+  
 # Installation
 
 Installation and activation takes a few steps, only `make install` needs root:
@@ -72,7 +65,7 @@ Installation and activation takes a few steps, only `make install` needs root:
 
 ```
 git clone https://github.com/dyne/dowse dowse-src
-cd dowse-src && git submodule update --init
+cd dowse-src && git submodule update --init --recursive
 ```
 
 2. Install all requirements, here below the list of packages. To avoid installing

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,13 +3,13 @@ PREFIX ?= /usr/local/dowse
 THREADS ?= 1
 
 CC = gcc
-CFLAGS = -Wall -fPIE -fPIC -pie -O3 -I.
-LIBS = -lhiredis -Llibdowse -l:libdowse.a
+CFLAGS = -Wall -fPIE -fPIC -pie -O3 -I. -Iredis/deps/hiredis -Iredis/deps/jemalloc
+LIBS = -L src/redis/deps/hiredis -l:libhiredis.a -Llibdowse -l:libdowse.a
 
 all: base springs
-	./import.sh redis-server
-	./import.sh redis-cli
 	./import.sh nmap-macs
+	install -s -p redis/src/redis-server ../build/bin
+	install -s -p redis/src/redis-cli ../build/bin
 	install -s -p modprobe        ../build/bin
 	install -s -p dowse-to-gource ../build/bin
 	install -s -p dowse-to-osc    ../build/bin
@@ -26,10 +26,13 @@ node-red:
 libs:
 	make -C libdowse
 
-.PHONY: dnscrypt-proxy libwebsockets modprobe netdata seccrond hiredis-lock mosquitto pgld sup
+.PHONY: redis dnscrypt-proxy libwebsockets modprobe netdata seccrond hiredis-lock mosquitto pgld sup
 
-base: config libs modprobe sup hiredis-lock dnscrypt-proxy dnscrypt_dowse.so netdata dhcpd libwebsockets mosquitto seccrond
+base: config libs redis modprobe sup hiredis-lock dnscrypt-proxy dnscrypt_dowse.so netdata dhcpd libwebsockets mosquitto seccrond
 	@echo "Compiled base"
+
+redis:
+	@./compile.sh redis ${THREADS}
 
 dnscrypt-proxy:
 	@./compile.sh dnscrypt-proxy ${THREADS}

--- a/src/Makefile
+++ b/src/Makefile
@@ -109,6 +109,7 @@ clean:
 	rm -f modprobe dowse-to-osc dowse-to-gource dowse-to-mqtt
 	rm -f hiredis-lock
 	rm -f netdata/web/version.txt
+	make -C redis				 clean
 	make -C dhcp                 clean
 	make -C sup                  clean
 	make -C dnscrypt-proxy       clean

--- a/src/compile.sh
+++ b/src/compile.sh
@@ -27,6 +27,15 @@ notice "Compiling $1 using ${THREADS} threads"
 
 
 case $1 in
+	redis)
+		[[ -r $R/src/redis/src/redis-server ]] && return 0
+		pushd $R/src/redis
+		CFLAGS="$CFLAGS" \
+			  LDFLAGS="$LDFLAGS" \
+			  make -j${THREADS}
+		popd
+		;;
+
 	log)
 		[[ -r $R/src/log/liblog.a ]] && return 0
 		pushd $R/src/log

--- a/src/compile.sh
+++ b/src/compile.sh
@@ -30,9 +30,8 @@ case $1 in
 	redis)
 		[[ -r $R/src/redis/src/redis-server ]] && return 0
 		pushd $R/src/redis
-		CFLAGS="$CFLAGS" \
-			  LDFLAGS="$LDFLAGS" \
-			  make -j${THREADS}
+		patch -NEp1 < $R/src/patches/redis_nodebug.patch
+		make -j${THREADS} V=1
 		popd
 		;;
 
@@ -100,7 +99,7 @@ case $1 in
     netdata)
         pushd $R/src/netdata
 		git checkout -- web
-		patch -p1 < $R/src/patches/netdata-dowse-integration.patch
+		patch -NEp1 < $R/src/patches/netdata-dowse-integration.patch
         ./autogen.sh
         CFLAGS="$CFLAGS" \
               ./configure --prefix=${PREFIX}/netdata \
@@ -131,7 +130,7 @@ case $1 in
         pushd $R/src/dnscrypt-proxy
 	## least bloated solution
 		git checkout -- src/proxy &&
-			patch -p1 < $R/src/patches/dnscrypt-noreuseableport.patch &&
+			patch -NEp1 < $R/src/patches/dnscrypt-noreuseableport.patch &&
 			./autogen.sh &&
 			./configure --without-systemd --enable-plugins --prefix=${PREFIX} &&
 			make -j${THREADS} &&
@@ -139,10 +138,10 @@ case $1 in
         popd
         ;;
 
-    dnscrypt_dowse.so)
+    dnscrypt_dowse.so|dnscrypt-plugin)
         pushd $R/src/dnscrypt-plugin
-		autoreconf -i &&
-			./configure &&
+		[[ -r configure ]] || autoreconf -i
+		./configure &&
 			make -j${THREADS} &&
             install -s -p .libs/dnscrypt_dowse.so $R/build/bin
         popd

--- a/src/dnscrypt-plugin/Makefile.am
+++ b/src/dnscrypt-plugin/Makefile.am
@@ -6,9 +6,9 @@ dnscrypt_dowse_la_LIBTOOLFLAGS = --tag=disable-static
 
 dnscrypt_dowse_la_SOURCES = dnscrypt-dowse.c domainlist.c ip2mac.c
 
-dnscrypt_dowse_la_LIBADD = @LDNS_LIBS@ -lhiredis -L../libdowse -l:libdowse.a
+dnscrypt_dowse_la_LIBADD = @LDNS_LIBS@ -L../redis/deps/hiredis -l:libhiredis.a -L../libdowse -l:libdowse.a
 
-dnscrypt_dowse_la_CFLAGS = -O3 -Wall -I../dnscrypt-proxy/src/include -I..
+dnscrypt_dowse_la_CFLAGS = -O3 -Wall -I../dnscrypt-proxy/src/include -I../redis/deps/hiredis -I..
 
 dnscrypt_dowse_la_LDFLAGS = $(AM_LDFLAGS) \
 -avoid-version \

--- a/src/dnscrypt-plugin/Makefile.am
+++ b/src/dnscrypt-plugin/Makefile.am
@@ -6,9 +6,9 @@ dnscrypt_dowse_la_LIBTOOLFLAGS = --tag=disable-static
 
 dnscrypt_dowse_la_SOURCES = dnscrypt-dowse.c domainlist.c ip2mac.c
 
-dnscrypt_dowse_la_LIBADD = @LDNS_LIBS@ -L../redis/deps/hiredis -l:libhiredis.a -L../libdowse -l:libdowse.a
+dnscrypt_dowse_la_LIBADD = @LDNS_LIBS@ -L../redis/deps/jemalloc/lib -l:libjemalloc.a -L../redis/deps/hiredis -l:libhiredis.a -L../libdowse -l:libdowse.a
 
-dnscrypt_dowse_la_CFLAGS = -O3 -Wall -I../dnscrypt-proxy/src/include -I../redis/deps/hiredis -I..
+dnscrypt_dowse_la_CFLAGS = -O3 -Wall -I../dnscrypt-proxy/src/include -I../redis/deps -I../redis/deps/hiredis -I..
 
 dnscrypt_dowse_la_LDFLAGS = $(AM_LDFLAGS) \
 -avoid-version \

--- a/src/dnscrypt-plugin/debug/build
+++ b/src/dnscrypt-plugin/debug/build
@@ -7,8 +7,9 @@ rm -f debug/*.o
 for s in $sources; do
 	o=${s%%.*}.o
 	gcc -c -ggdb -Wall -Wextra -pedantic -std=gnu99 -I. -fPIC -DPIC \
-		-DDEBUG=1 -I../dnscrypt-proxy/src/include -I.. -I../redis/deps/hiredis \
-	 $s -o debug/$o
+		-DDEBUG=1 -I../dnscrypt-proxy/src/include -I.. -I../redis/deps \
+		-I../redis/deps/hiredis \
+		$s -o debug/$o
 	objs+=(debug/$o)
 done
 

--- a/src/dnscrypt-plugin/debug/build
+++ b/src/dnscrypt-plugin/debug/build
@@ -6,12 +6,12 @@ objs=()
 rm -f debug/*.o
 for s in $sources; do
 	o=${s%%.*}.o
-	gcc -c -ggdb -Wall -I. -fPIC -DPIC \
-		-DDEBUG=1 -I../dnscrypt-proxy/src/include -I.. \
+	gcc -c -ggdb -Wall -Wextra -pedantic -std=gnu99 -I. -fPIC -DPIC \
+		-DDEBUG=1 -I../dnscrypt-proxy/src/include -I.. -I../redis/deps/hiredis \
 	 $s -o debug/$o
 	objs+=(debug/$o)
 done
 
 rm -f debug/dnscrypt_dowse.so
 gcc -fPIC -DPIC -shared -o debug/dnscrypt_dowse.so $objs \
-	-lldns -lhiredis -L../libdowse -l:libdowse.a
+	-lldns -L../redis/deps/hiredis -l:libhiredis.a -L../libdowse -l:libdowse.a

--- a/src/dnscrypt-plugin/debug/runtests
+++ b/src/dnscrypt-plugin/debug/runtests
@@ -12,10 +12,13 @@ notice "Test session on Dowse DNSCrypt plugin"
 act "`date`"
 
 start redis-server
+start redis-volatile
 
 act "hostname: $hostname"
 act "address: $address"
 act "wan: $wan"
+
+sleep 1
 
 cat <<EOF | redis dynamic
 SET dns-lease-testlease1 10.0.0.101
@@ -27,30 +30,32 @@ SET dns-reverse-${address}. ${hostname}
 EOF
 # SET dns-reverse-${wan}. gateway
 
-DOWSE_DOMAINLIST=`pwd`/../domain-list/data 
-DOWSE_LAN_ADDRESS_IP4=$address 
-DOWSE_LAN_NETMASK_IP4=$netmask 
-hostname=$hostname 
-interface=$interface
-domain=$lan	
-valgrind --leak-check=full \--track-origins=yes \
-	 ../dnscrypt-proxy/src/proxy/dnscrypt-proxy \
-	 -a $address:54540 \
-	 -l debug/runtests.log \
-	 -L ../dnscrypt-proxy/dnscrypt-resolvers.csv \
-	 -R "ipredator" \
-	 -X `pwd`/debug/dnscrypt_dowse.so,debug \
-	 -m 7 -d
+DOWSE_DOMAINLIST=`pwd`/../domain-list/data \
+				DOWSE_LAN_ADDRESS_IP4=$address \
+				DOWSE_LAN_NETMASK_IP4=$netmask \
+				hostname=$hostname \
+				interface=$interface \
+				domain=$lan	\
+				valgrind --leak-check=full \--track-origins=yes \
+				../dnscrypt-proxy/src/proxy/dnscrypt-proxy \
+				-a $address:54540 \
+				-l debug/runtests.log \
+				-L ../dnscrypt-proxy/dnscrypt-resolvers.csv \
+				-R "ipredator" \
+				-X `pwd`/debug/dnscrypt_dowse.so,debug \
+				-m 7 -d
 # log level informational (7 for debug)
 
 
 sleep 3
 
 notice own_hostname
-dig @$address -p 54540 $hostname || return 1
+act "dig @$address -p 54540 $hostname"
+dig @$address -p 54540 $hostname
 
 notice own_address_reverse
-dig @$address -p 54540 -x $address || return 1
+act "dig @$address -p 54540 -x $address"
+dig @$address -p 54540 -x $address
 
 # run tests offline
 
@@ -61,19 +66,24 @@ dig @$address -p 54540 -x $address || return 1
 # dig @$address -p 54540 sigok.verteiltesysteme.net || return 1
 
 notice 10.0.0.101
-dig @$address -p 54540 -x 10.0.0.101 || return 1
+act "dig @$address -p 54540 -x 10.0.0.101"
+dig @$address -p 54540 -x 10.0.0.101
 
 notice 10.0.0.102
-dig @$address -p 54540 -x 10.0.0.102 || return 1
+act "dig @$address -p 54540 -x 10.0.0.102"
+dig @$address -p 54540 -x 10.0.0.102
 
 notice testlease1
-dig @$address -p 54540 testlease1 || return 1
+act "dig @$address -p 54540 testlease1"
+dig @$address -p 54540 testlease1
 
 notice testlease2
-dig @$address -p 54540 testlease2.dowse.it || return 1
+act "dig @$address -p 54540 testlease2.dowse.it"
+dig @$address -p 54540 testlease2.dowse.it
 
 notice gateway
-dig @$address -p 54540 gateway || return 1
+act "dig @$address -p 54540 gateway"
+dig @$address -p 54540 gateway
 
 
 notice "dnscrypt-plugin - all tests OK"

--- a/src/libdowse/Makefile
+++ b/src/libdowse/Makefile
@@ -1,4 +1,4 @@
-CFLAGS ?= -ggdb -Wall  -fPIE -fPIC -pie
+CFLAGS ?= -O2 -Wall  -fPIE -fPIC -pie -I ../redis/deps/hiredis
 #-DDEBUG=1
 
 CC = gcc

--- a/src/libdowse/dowse.h
+++ b/src/libdowse/dowse.h
@@ -21,7 +21,7 @@
 #ifndef __LIBDOWSE_H__
 #define __LIBDOWSE_H__
 
-#include <hiredis/hiredis.h>
+#include <hiredis.h>
 #include <database.h>
 
 // logging channel singleton in libdowse

--- a/src/patches/redis_nodebug.patch
+++ b/src/patches/redis_nodebug.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Makefile b/src/Makefile
+index b896b126..a11e8f48 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -66,7 +66,7 @@ endif
+ FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(REDIS_CFLAGS)
+ FINAL_LDFLAGS=$(LDFLAGS) $(REDIS_LDFLAGS) $(DEBUG)
+ FINAL_LIBS=-lm
+-DEBUG=-g -ggdb
++DEBUG=
+ 
+ ifeq ($(uname_S),SunOS)
+ 	# SunOS


### PR DESCRIPTION
Stop using system-wide redis: we build our own, the latest and the greatest, with the advantage of having hiredis and jemalloc from inside the source code. Redis is such a vital part of Dowse that this move makes sense. 